### PR TITLE
Round the price to less decimals to prevent beancount from loading failure

### DIFF
--- a/price_sources/coinmarketcap.py
+++ b/price_sources/coinmarketcap.py
@@ -58,7 +58,7 @@ class Source(source.Source):
                 quote = quote[0]
 
             date = parser.isoparse(quote['quote'][CURRENCY]['timestamp'])
-            price = D(quote['quote'][CURRENCY]['close'])
+            price = D(quote['quote'][CURRENCY]['close']).quantize(D('0.0000'))
 
             return source.SourcePrice(price, date, CURRENCY)
         except KeyError as e:


### PR DESCRIPTION
The price retrieved from CoinMarketCap have more decimals than necessary for some currency. If the number is not rounded, beancount will fail to load. Though I'm not sure the precision beancount supported, I think four decimals should be sufficient for most recording purpose.